### PR TITLE
Add a CommonJS build and fix the UMD build

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,19 +1,16 @@
 {
   "name": "redbox-react",
   "description": "A redbox (rsod) component to display your errors.",
-  "main": "dist/redbox.js",
-  "browser": {
-    "index.js": "dist/redbox.js"
-  },
+  "main": "lib/index.js",
   "scripts": {
-    "clean": "rimraf dist tmp",
-    "build:dev": "webpack src/index.js dist/redbox.js",
-    "build:prod": "NODE_ENV=production webpack src/index.js dist/redbox.min.js",
-    "build:test": "TEST=true webpack src/index.js tmp/redbox.js",
-    "build": "npm run build:dev && npm run build:prod",
+    "clean": "rimraf dist lib tmp",
+    "build:umd": "webpack src/index.js dist/redbox.js",
+    "build:umd:min": "NODE_ENV=production webpack src/index.js dist/redbox.min.js",
+    "build:lib": "NODE_ENV=production babel src --out-dir lib",
+    "build": "npm run build:umd && npm run build:umd:min && npm run build:lib",
     "lint": "standard ./src",
     "prepublish": "npm run clean && npm run build",
-    "test": "npm run lint -s && npm run build:test -s && babel-node ./tests | tap-spec",
+    "test": "npm run lint -s && babel-node ./tests | tap-spec",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "repository": {

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,6 +1,6 @@
 import test from 'tape'
 import {createComponent} from './utils'
-import RedBox from '../tmp/redbox'
+import RedBox from '../src'
 
 test('RedBox static displayName', t => {
   t.plan(1)

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,12 +3,6 @@
 // imports
 var webpack = require('webpack')
 
-// configurations
-var PROD
-if (process.env.NODE_ENV === 'production') {
-  PROD = true
-}
-
 // base set of plugins, used in any configuration
 var plugins = [
   new webpack.optimize.OccurenceOrderPlugin(),
@@ -16,6 +10,18 @@ var plugins = [
     'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV)
   })
 ]
+
+// production configuration
+if (process.env.NODE_ENV === 'production') {
+  plugins.push(
+    new webpack.optimize.UglifyJsPlugin({
+      compressor: {
+        screw_ie8: true,
+        warnings: false
+      }
+    })
+  )
+}
 
 let config = {
   module: {
@@ -26,27 +32,18 @@ let config = {
     }]
   },
   externals: {
-    'react': 'react'
+    'react': {
+      root: 'React',
+      commonjs2: 'react',
+      commonjs: 'react',
+      amd: 'react'
+    }
   },
   output: {
-    library: 'redbox-react',
+    library: 'redbox',
     libraryTarget: 'umd'
   },
-  plugins: plugins,
-  resolve: {
-    extensions: ['', '.js']
-  }
-}
-
-if (PROD) {
-  config.plugins.push(
-    new webpack.optimize.UglifyJsPlugin({
-      compressor: {
-        screw_ie8: true,
-        warnings: false
-      }
-    })
-  )
+  plugins: plugins
 }
 
 module.exports = config


### PR DESCRIPTION
The first commit adds a build step for CommonJS files to be consumed via Browserify and Webpack.
It changes `main` to point to `lib/index.js` because this is the CommonJS entry point.
It fixes "Cannot find module 'stackframe'" when compiling with Browserify (https://github.com/KeywordBrain/redbox-react/issues/17#issuecomment-140860875).

The second commit fixes the UMD build:
1. Now, in a require-less environment, it looks for a "React" global instead of "react" global which was wrong
2. The exported global name is now "redbox" instead of "redbox-react" to match the filename and remove the dash in global

Whether you'd like to merge this, or go through with https://github.com/KeywordBrain/redbox-react/pull/18 is up to you of course. Unlike #18, it keeps the UMD build—just fixes it to be correct, and also fixes it not to be used in Node environment, which was also incorrect.

Either #18 or this needs to merged though ASAP because Browserify support is currently broken due to the lack of a CommonJS build. Merging this will close #17.