### PR TITLE
avoid setting Node environment variables via npm script

### DIFF
--- a/make-webpack-config.js
+++ b/make-webpack-config.js
@@ -1,0 +1,49 @@
+'use strict'
+// imports
+var webpack = require('webpack')
+
+module.exports = function(options){
+
+  // base set of plugins, used in any configuration
+  var plugins = [
+    new webpack.optimize.OccurenceOrderPlugin(),
+    new webpack.DefinePlugin({
+      'process.env.NODE_ENV': JSON.stringify(options.nodeEnv)
+    })
+  ]
+
+  // production configuration
+  if (options.minimize) {
+    plugins.push(
+      new webpack.optimize.UglifyJsPlugin({
+        compressor: {
+          screw_ie8: true,
+          warnings: false
+        }
+      })
+    )
+  }
+
+  return {
+    module: {
+      loaders: [{
+        test: /\.js$/,
+        loaders: ['babel-loader'],
+        exclude: /node_modules/
+      }]
+    },
+    externals: {
+      'react': {
+        root: 'React',
+        commonjs2: 'react',
+        commonjs: 'react',
+        amd: 'react'
+      }
+    },
+    output: {
+      library: 'redbox',
+      libraryTarget: 'umd'
+    },
+    plugins: plugins
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "clean": "rimraf dist lib tmp",
     "build:umd": "webpack src/index.js dist/redbox.js",
-    "build:umd:min": "NODE_ENV=production webpack src/index.js dist/redbox.min.js",
-    "build:lib": "NODE_ENV=production babel src --out-dir lib",
+    "build:umd:min": "webpack --config webpack.config.prod.js src/index.js dist/redbox.min.js",
+    "build:lib": "babel src --out-dir lib",
     "build": "npm run build:umd && npm run build:umd:min && npm run build:lib",
     "lint": "standard ./src",
     "prepublish": "npm run clean && npm run build",

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -1,4 +1,4 @@
 module.exports = require("./make-webpack-config")({
-	minimize: false,
-	nodeEnv: "development"
+	minimize: true,
+	nodeEnv: 'production'
 });


### PR DESCRIPTION
Intent is to allow for Windows compatibility, setting NODE_ENV variables via npm script is troublesome.

Changes largely taken from https://github.com/webpack/react-starter.  
Let me know your thoughts.  Cool thing is doesnt change environment variables on system.