### PR TITLE
Append RedBox to document.body via a 'portal'

### DIFF
--- a/examples/babel-plugin-react-hot/webpack.config.js
+++ b/examples/babel-plugin-react-hot/webpack.config.js
@@ -3,7 +3,7 @@ var path = require('path')
 
 module.exports = {
   entry: [
-    'webpack-dev-server/client?http://localhost:3000',
+    'webpack-dev-server/client?http://localhost:3001',
     'webpack/hot/only-dev-server',
     './index.js'
   ],

--- a/src/index.js
+++ b/src/index.js
@@ -3,11 +3,11 @@ import style from './style.js'
 import ErrorStackParser from 'error-stack-parser'
 import assign from 'object-assign'
 
-export default class RedBox extends Component {
+export class RedBoxError extends Component {
   static propTypes = {
     error: PropTypes.instanceOf(Error).isRequired
   }
-  static displayName = 'RedBox'
+  static displayName = 'RedBoxError'
   render () {
     const {error} = this.props
     const {redbox, message, stack, frame, file, linkToFile} = assign({}, style, this.props.style)
@@ -31,3 +31,30 @@ export default class RedBox extends Component {
     )
   }
 }
+
+export default class RedBox extends Component {
+  static propTypes = {
+    error: PropTypes.instanceOf(Error).isRequired
+  }
+  static displayName = 'RedBox'
+  componentDidMount () {
+    this.el = document.createElement('div')
+    document.body.appendChild(this.el)
+    this.renderRedBoxError()
+  }
+  componentDidUpdate () {
+    this.renderRedBoxError()
+  }
+  componentWillUnmount () {
+    React.unmountComponentAtNode(this.el)
+    document.body.removeChild(this.el)
+    this.el = null
+  }
+  renderRedBoxError () {
+    React.render(<RedBoxError {...this.props}/>, this.el)
+  }
+  render () {
+    return null
+  }
+}
+


### PR DESCRIPTION
This is a first stab at resolving #27. A couple notes:

- This will trigger deprecation warnings in React >= 0.14.x due to the DOM stuff being split out.
- I didn't update the tests, so they are failing.
- It took a little version juggling to get `examples/babel-plugin-react-hot` to work properly, because its version of react didn't match the main one.

So take this more as an example of the approach. To merge, I imagine we'll need:

- Passing tests
- Decide what to do about React 0.14.x
- Take a pass at 'fixing' the examples so they run out-of-the-box with a fresh `git clone`