### PR TITLE
Allow links to open files in configured editor

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,7 @@
 {
   "stage": 0,
-  "loose": "all"
+  "loose": "all",
+  "plugins": [
+    "rewire"
+  ]
 }

--- a/README.md
+++ b/README.md
@@ -46,3 +46,23 @@ An error that's only in the console is only half the fun. Now you can use all th
 
 ## Will this catch errors for me?
 No. As you can see above, this is only a UI component for rendering errors and their stack traces. It's works great with other solutions, that automate the error catching for you, see the [examples](https://github.com/KeywordBrain/redbox-react/tree/master/examples).
+
+## Optional props
+
+`editorScheme` `[?string]` If a filename in the stack trace is local, the component can create the
+link to open your editor using this scheme eg: `subl` to create `subl://open?url=file:///filename`.
+
+`useLines` `[boolean=true]` Line numbers in the stack trace may be unreliable depending on the
+type of sourcemaps. You can choose to not display them with this flag.
+
+`useColumns` `[boolean=true]` Column numbers in the stack trace may be unreliable depending on the
+type of sourcemaps. You can choose to not display them with this flag.
+
+If using [react-transform-catch-errors](https://github.com/gaearon/react-transform-catch-errors#installation) you can add these options to your `.babelrc` through the [`imports` property](https://github.com/gaearon/react-transform-catch-errors#installation).
+
+## Sourcemaps with Webpack
+
+If using [Webpack](https://webpack.github.io) you can get accurate filenames in the stacktrace by
+setting the `output.devtoolModuleFilenameTemplate` settings to `/[absolute-resource-path]`.
+
+It's recommended to set `devtool` setting to `'eval'`.

--- a/package.json
+++ b/package.json
@@ -34,13 +34,14 @@
     "babel-core": "^5.6.18",
     "babel-eslint": "^3.1.15",
     "babel-loader": "^5.1.4",
+    "babel-plugin-rewire": "^0.1.22",
     "rimraf": "^2.3.4",
+    "semantic-release": "^4.0.0",
     "standard": "^5.0.0-2",
     "tap-spec": "^4.0.2",
     "tape": "^4.0.1",
     "webpack": "^1.9.6",
-    "webpack-dev-server": "^1.8.2",
-    "semantic-release": "^4.0.0"
+    "webpack-dev-server": "^1.8.2"
   },
   "peerDependencies": {
     "react": ">=0.13.2 || ^0.14.0-rc1"

--- a/src/index.js
+++ b/src/index.js
@@ -2,23 +2,44 @@ import React, {Component, PropTypes} from 'react'
 import style from './style.js'
 import ErrorStackParser from 'error-stack-parser'
 import assign from 'object-assign'
+import {isFilenameAbsolute, makeUrl, makeLinkText} from './lib'
 
 export default class RedBox extends Component {
   static propTypes = {
-    error: PropTypes.instanceOf(Error).isRequired
+    error: PropTypes.instanceOf(Error).isRequired,
+    filename: PropTypes.string,
+    editorScheme: PropTypes.string,
+    useLines: PropTypes.bool,
+    useColumns: PropTypes.bool
   }
   static displayName = 'RedBox'
+  static defaultProps = {
+    useLines: true,
+    useColumns: true
+  }
   render () {
-    const {error} = this.props
+    const {error, filename, editorScheme, useLines, useColumns} = this.props
     const {redbox, message, stack, frame, file, linkToFile} = assign({}, style, this.props.style)
 
     const frames = ErrorStackParser.parse(error).map((f, index) => {
-      const link = `${f.fileName}:${f.lineNumber}:${f.columnNumber}`
+      let text
+      let url
+
+      if (index === 0 && filename && !isFilenameAbsolute(f.fileName)) {
+        url = makeUrl(filename, editorScheme)
+        text = makeLinkText(filename)
+      } else {
+        let lines = useLines ? f.lineNumber : null
+        let columns = useColumns ? f.columnNumber : null
+        url = makeUrl(f.fileName, editorScheme, lines, columns)
+        text = makeLinkText(f.fileName, lines, columns)
+      }
+
       return (
         <div style={frame} key={index}>
           <div>{f.functionName}</div>
           <div style={file}>
-            <a href={link} style={linkToFile}>{link}</a>
+            <a href={url} style={linkToFile}>{text}</a>
           </div>
         </div>
       )

--- a/src/lib.js
+++ b/src/lib.js
@@ -1,0 +1,63 @@
+export const filenameWithoutLoaders = (filename) => {
+  var index = filename.lastIndexOf('!')
+
+  return index < 0 ? filename : filename.substr(index + 1)
+}
+
+export const filenameHasLoaders = (filename) => {
+  const actualFilename = filenameWithoutLoaders(filename)
+
+  return actualFilename !== filename
+}
+
+export const filenameHasSchema = (filename) => {
+  return /^[\w]+\:/.test(filename)
+}
+
+export const isFilenameAbsolute = (filename) => {
+  const actualFilename = filenameWithoutLoaders(filename)
+
+  if (actualFilename.indexOf('/') === 0) {
+    return true
+  }
+
+  return false
+}
+
+export const makeUrl = (filename, scheme, line, column) => {
+  let actualFilename = filenameWithoutLoaders(filename)
+
+  if (filenameHasSchema(filename)) {
+    return actualFilename
+  }
+
+  let url = `file://${actualFilename}`
+
+  if (scheme) {
+    url = `${scheme}://open?url=${url}`
+
+    if (line && actualFilename === filename) {
+      url = `${url}&line=${line}`
+
+      if (column) {
+        url = `${url}&column=${column}`
+      }
+    }
+  }
+
+  return url
+}
+
+export const makeLinkText = (filename, line, column) => {
+  let text = filenameWithoutLoaders(filename)
+
+  if (line && text === filename) {
+    text = `${text}:${line}`
+
+    if (column) {
+      text = `${text}:${column}`
+    }
+  }
+
+  return text
+}

--- a/tests/errorStackParserMock.js
+++ b/tests/errorStackParserMock.js
@@ -1,5 +1,5 @@
-import framesStub from './framesStub.json'
-
-export default {
-  parse: () => framesStub
+export default (framesStub) => {
+  return {
+    parse: () => framesStub
+  }
 }

--- a/tests/framesStubAbsoluteFilenames.json
+++ b/tests/framesStubAbsoluteFilenames.json
@@ -1,13 +1,13 @@
 [
   {
     "functionName": "App.render",
-    "fileName": "webpack:\/\/\/.\/components\/App.js?",
+    "fileName": "\/components\/App.js",
     "lineNumber": 45,
     "columnNumber": 12
   },
   {
     "functionName": "App.render",
-    "fileName": "webpack:\/\/\/.\/~\/react-hot-loader\/~\/react-hot-api\/modules\/makeAssimilatePrototype.js?",
+    "fileName": "\/some-path\/modules\/makeAssimilatePrototype.js",
     "lineNumber": 17,
     "columnNumber": 41
   }

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,18 +1,36 @@
+import React from 'react'
 import test from 'tape'
 import {createComponent} from './utils'
+import errorStackParserMock from './errorStackParserMock'
+import framesStub from './framesStub.json'
+import framesStubAbsoluteFilenames from './framesStubAbsoluteFilenames.json'
 import RedBox from '../src'
+import style from '../src/style'
+import './lib';
+
+
+const beforeEach = (framesStub) => {
+  RedBox.__Rewire__('ErrorStackParser', errorStackParserMock(framesStub))
+}
+
+const afterEach = () => {
+  RedBox.__ResetDependency__('ErrorStackParser')
+}
 
 test('RedBox static displayName', t => {
   t.plan(1)
+  beforeEach(framesStub)
   t.equal(
     RedBox.displayName,
     'RedBox',
     'correct static displayName property on class'
   )
+  afterEach()
 })
 
 test('RedBox error message', t => {
   t.plan(3)
+  beforeEach(framesStub)
   const ERR_MESSAGE = 'funny error name'
   const error = new Error(ERR_MESSAGE)
   const component = createComponent(RedBox, {error})
@@ -35,6 +53,191 @@ test('RedBox error message', t => {
     ERR_MESSAGE,
     'Main error message ends with message originally supplied to error constructor.'
   )
+  afterEach()
 })
 
-// TODO: Tests for the stack frame rendering
+test('RedBox stack trace', t => {
+  t.plan(1)
+  beforeEach(framesStub)
+  const error = new Error()
+  const component = createComponent(RedBox, {error})
+
+  const renderedStack = component
+    .props.children[1]
+
+  t.deepEqual(
+    renderedStack,
+    <div style={style.stack}>
+      <div style={style.frame} key={0}>
+        <div>App.render</div>
+        <div style={style.file}>
+          <a style={style.linkToFile} href="webpack:///./components/App.js?">webpack:///./components/App.js?:45:12</a>
+        </div>
+      </div>
+      <div style={style.frame} key={1}>
+        <div>App.render</div>
+        <div style={style.file}>
+          <a style={style.linkToFile} href="webpack:///./~/react-hot-loader/~/react-hot-api/modules/makeAssimilatePrototype.js?">webpack:///./~/react-hot-loader/~/react-hot-api/modules/makeAssimilatePrototype.js?:17:41</a>
+        </div>
+      </div>
+    </div>
+  )
+
+  afterEach()
+})
+
+test('RedBox with filename from react-transform-catch-errors', t => {
+  t.plan(1)
+  beforeEach(framesStub)
+  const error = new Error()
+  const filename = 'some-optional-webpack-loader!/filename'
+  const component = createComponent(RedBox, {error, filename})
+
+  const renderedStack = component
+    .props.children[1]
+
+  t.deepEqual(
+    renderedStack,
+    <div style={style.stack}>
+      <div style={style.frame} key={0}>
+        <div>App.render</div>
+        <div style={style.file}>
+          <a style={style.linkToFile} href="file:///filename">/filename</a>
+        </div>
+      </div>
+      <div style={style.frame} key={1}>
+        <div>App.render</div>
+        <div style={style.file}>
+          <a style={style.linkToFile} href="webpack:///./~/react-hot-loader/~/react-hot-api/modules/makeAssimilatePrototype.js?">webpack:///./~/react-hot-loader/~/react-hot-api/modules/makeAssimilatePrototype.js?:17:41</a>
+        </div>
+      </div>
+    </div>
+  )
+  afterEach()
+})
+
+test('RedBox with filename and editorScheme', t => {
+  t.plan(1)
+  beforeEach(framesStub)
+  const error = new Error()
+  const filename = 'some-optional-webpack-loader!/filename'
+  const editorScheme = 'subl'
+  const component = createComponent(RedBox, {error, filename, editorScheme})
+
+  const renderedStack = component
+    .props.children[1]
+
+  t.deepEqual(
+    renderedStack,
+    <div style={style.stack}>
+      <div style={style.frame} key={0}>
+        <div>App.render</div>
+        <div style={style.file}>
+          <a style={style.linkToFile} href="subl://open?url=file:///filename">/filename</a>
+        </div>
+      </div>
+      <div style={style.frame} key={1}>
+        <div>App.render</div>
+        <div style={style.file}>
+          <a style={style.linkToFile} href="webpack:///./~/react-hot-loader/~/react-hot-api/modules/makeAssimilatePrototype.js?">webpack:///./~/react-hot-loader/~/react-hot-api/modules/makeAssimilatePrototype.js?:17:41</a>
+        </div>
+      </div>
+    </div>
+  )
+  afterEach()
+})
+
+test('RedBox with absolute filenames', t => {
+  t.plan(1)
+  beforeEach(framesStubAbsoluteFilenames)
+  const error = new Error()
+  const filename = 'some-optional-webpack-loader!/filename'
+  const editorScheme = 'subl'
+  const component = createComponent(RedBox, {error, filename, editorScheme})
+
+  const renderedStack = component
+    .props.children[1]
+
+  t.deepEqual(
+    renderedStack,
+    <div style={style.stack}>
+      <div style={style.frame} key={0}>
+        <div>App.render</div>
+        <div style={style.file}>
+          <a style={style.linkToFile} href="subl://open?url=file:///components/App.js&line=45&column=12">/components/App.js:45:12</a>
+        </div>
+      </div>
+      <div style={style.frame} key={1}>
+        <div>App.render</div>
+        <div style={style.file}>
+          <a style={style.linkToFile} href="subl://open?url=file:///some-path/modules/makeAssimilatePrototype.js&line=17&column=41">/some-path/modules/makeAssimilatePrototype.js:17:41</a>
+        </div>
+      </div>
+    </div>
+  )
+  afterEach()
+})
+
+test('RedBox with absolute filenames but unreliable line numbers', t => {
+  t.plan(1)
+  beforeEach(framesStubAbsoluteFilenames)
+  const error = new Error()
+  const filename = 'some-optional-webpack-loader!/filename'
+  const editorScheme = 'subl'
+  const useLines = false
+  const component = createComponent(RedBox, {error, filename, editorScheme, useLines})
+
+  const renderedStack = component
+    .props.children[1]
+
+  t.deepEqual(
+    renderedStack,
+    <div style={style.stack}>
+      <div style={style.frame} key={0}>
+        <div>App.render</div>
+        <div style={style.file}>
+          <a style={style.linkToFile} href="subl://open?url=file:///components/App.js">/components/App.js</a>
+        </div>
+      </div>
+      <div style={style.frame} key={1}>
+        <div>App.render</div>
+        <div style={style.file}>
+          <a style={style.linkToFile} href="subl://open?url=file:///some-path/modules/makeAssimilatePrototype.js">/some-path/modules/makeAssimilatePrototype.js</a>
+        </div>
+      </div>
+    </div>
+  )
+  afterEach()
+})
+
+test('RedBox with absolute filenames but unreliable column numbers', t => {
+  t.plan(1)
+  beforeEach(framesStubAbsoluteFilenames)
+  const error = new Error()
+  const filename = 'some-optional-webpack-loader!/filename'
+  const editorScheme = 'subl'
+  const useColumns = false
+  const component = createComponent(RedBox, {error, filename, editorScheme, useColumns})
+
+  const renderedStack = component
+    .props.children[1]
+
+  t.deepEqual(
+    renderedStack,
+    <div style={style.stack}>
+      <div style={style.frame} key={0}>
+        <div>App.render</div>
+        <div style={style.file}>
+          <a style={style.linkToFile} href="subl://open?url=file:///components/App.js&line=45">/components/App.js:45</a>
+        </div>
+      </div>
+      <div style={style.frame} key={1}>
+        <div>App.render</div>
+        <div style={style.file}>
+          <a style={style.linkToFile} href="subl://open?url=file:///some-path/modules/makeAssimilatePrototype.js&line=17">/some-path/modules/makeAssimilatePrototype.js:17</a>
+        </div>
+      </div>
+    </div>
+  )
+  afterEach()
+})

--- a/tests/lib.js
+++ b/tests/lib.js
@@ -1,0 +1,143 @@
+import test from 'tape'
+import {
+  filenameWithoutLoaders,
+  filenameHasLoaders,
+  isFilenameAbsolute,
+  filenameHasSchema,
+  makeUrl,
+  makeLinkText
+} from '../src/lib'
+
+test('filenameWithoutLoaders', t => {
+  t.plan(3)
+  t.equal(
+    filenameWithoutLoaders('/webpack-loader!/filename'),
+    '/filename',
+    'Should handle webpack loader'
+  )
+  t.equal(
+    filenameWithoutLoaders('/filename'),
+    '/filename',
+    'Should handle no loader'
+  )
+  t.equal(
+    filenameWithoutLoaders('http://doman/path'),
+    'http://doman/path',
+    'Should handle URL'
+  )
+})
+
+test('filenameHasLoaders', t => {
+  t.plan(3)
+  t.true(
+    filenameHasLoaders('/webpack-loader!/filename'),
+    'Should handle webpack loader'
+  )
+  t.false(
+    filenameHasLoaders('/filename'),
+    'Should handle no loader'
+  )
+  t.false(
+    filenameHasLoaders('http://doman/path'),
+    'Should handle URL'
+  )
+})
+
+test('isFilenameAbsolute', t => {
+  t.plan(4)
+  t.false(
+    isFilenameAbsolute('webpack://filename'),
+    'webpack://filename is not absolute'
+  )
+  t.false(
+    isFilenameAbsolute('./filename'),
+    './filename is not absolute'
+  )
+  t.true(
+    isFilenameAbsolute('/filename'),
+    '/filename is absolute'
+  )
+  t.true(
+    isFilenameAbsolute('loader!/filename'),
+    'loader!/filename is absolute'
+  )
+})
+
+test('filenameHasSchema', t => {
+  t.plan(3)
+  t.false(
+    filenameHasSchema('/filename'),
+    '/filename has no schema'
+  )
+  t.true(
+    filenameHasSchema('http://filename'),
+    'http://filename has a schema'
+  )
+  t.true(
+    filenameHasSchema('webpack:filename'),
+    'webpack:filename has a schema'
+  )
+})
+
+test('makeUrl', t => {
+  t.plan(7)
+  t.equal(
+    makeUrl('/filename'),
+    'file:///filename',
+    'Should handle local file'
+  )
+  t.equal(
+    makeUrl('http://filename'),
+    'http://filename',
+    'Should handle URL'
+  )
+  t.equal(
+    makeUrl('/filename', 'subl'),
+    'subl://open?url=file:///filename',
+    'Should handle local file with scheme'
+  )
+  t.equal(
+    makeUrl('/filename', 'subl', 10),
+    'subl://open?url=file:///filename&line=10',
+    'Should handle local file with scheme and line'
+  )
+  t.equal(
+    makeUrl('/filename', 'subl', 10, 3),
+    'subl://open?url=file:///filename&line=10&column=3',
+    'Should handle local file with scheme, kine and column'
+  )
+  t.equal(
+    makeUrl('http://filename', 'subl'),
+    'http://filename',
+    'Should handle URL with scheme'
+  )
+  t.equal(
+    makeUrl('/loader!/filename', 'subl', 10),
+    'subl://open?url=file:///filename',
+    'Should handle webpack loader with line'
+  )
+})
+
+test('makeLinkText', t => {
+  t.plan(4)
+  t.equal(
+    makeLinkText('/filename'),
+    '/filename',
+    'Should handle filename'
+  )
+  t.equal(
+    makeLinkText('/filename', 10),
+    '/filename:10',
+    'Should handle filename and line'
+  )
+  t.equal(
+    makeLinkText('/filename', 10, 3),
+    '/filename:10:3',
+    'Should handle filename, line and column'
+  )
+  t.equal(
+    makeLinkText('/loader!/filename', 10),
+    '/filename',
+    'Should handle filename with webpack loader and line'
+  )
+})


### PR DESCRIPTION
If filenames are absolute the generated links can be opened in an editor if the `editorScheme` property is set.

**Note:** Currently an "absolute filename" means "starts with `/`". Is this enough? What about Windows? I don't know. It would be possible to convert relative filenames such as `./filename` with a base path configuration but webpack also produces paths like `./~/filename` which get ambiguous.

If `react-transform-catch-errors` passes in a `filename` this is used for the top function if the stack trace filename isn't absolute.

I've tried to cover the scenarios I know about but I'm sure there's others that I will have missed.

Closes: #10