### PR TITLE
Add z-index for redbox to appear above everything

### DIFF
--- a/src/redbox.css
+++ b/src/redbox.css
@@ -10,6 +10,7 @@
   width: 100%;
   background: rgb(204, 0, 0);
   color: white;
+  z-index: 16777271;
 }
 
 .redbox .message {


### PR DESCRIPTION
The redbox appears below dialogs/modals on a project that I'm working on. This ensures that it appears above.