### PR TITLE
Let npm ignore the examples folder

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,7 @@
 # common
 
 coverage
+examples
 node_modules
 tmp
 *.log


### PR DESCRIPTION
I added "examples" to the `.npmignore` to remove them from npm.