### PR TITLE
move rewire from devDependencies to dependencies fixes KeywordBrain/r…

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "babel-core": "^5.6.18",
     "babel-eslint": "^3.1.15",
     "babel-loader": "^5.1.4",
-    "babel-plugin-rewire": "^0.1.22",
     "rimraf": "^2.3.4",
     "semantic-release": "^4.0.0",
     "standard": "^5.0.0-2",
@@ -47,6 +46,7 @@
     "react": ">=0.13.2 || ^0.14.0-rc1"
   },
   "dependencies": {
+    "babel-plugin-rewire": "^0.1.22",
     "error-stack-parser": "^1.2.0",
     "object-assign": "^4.0.1"
   },


### PR DESCRIPTION
It appears that babel-plugin-rewire should be a dependency, not a devDependency. 

https://github.com/KeywordBrain/redbox-react/issues/34
https://github.com/nsmith7989/redux-filter/issues/21