### PR TITLE
bump the dependency on error-stack-parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "react": "^0.14.0 || ^15.0.0"
   },
   "dependencies": {
-    "error-stack-parser": "^1.2.0",
+    "error-stack-parser": "^1.3.6",
     "object-assign": "^4.0.1"
   },
   "standard": {


### PR DESCRIPTION
because lower versions are causing this: https://github.com/gaearon/react-hot-loader/issues/292