### PR TITLE
Portal implementation to mount to body directly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,7 @@ cache:
 notifications:
   email: false
 node_js:
-  - iojs
-before_install:
-  - npm i -g npm@^2.0.0
-  - npm i -g babel-cli
+  - "stable"
 before_script:
   - npm prune
 after_success:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # redbox-react
 
 [![Build Status](https://travis-ci.org/KeywordBrain/redbox-react.svg?branch=master)](https://travis-ci.org/KeywordBrain/redbox-react)
+[![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 
 The red box (aka red screen of death) renders an error in this “pretty” format:
 

--- a/examples/react-hot-loader/index-portal.js
+++ b/examples/react-hot-loader/index-portal.js
@@ -1,0 +1,38 @@
+import React from 'react'
+import {render} from 'react-dom'
+import {AppContainer} from 'react-hot-loader'
+import App from './components/App'
+import Redbox from 'redbox-react'
+
+const root = document.getElementById('root')
+const stylesBox = {
+  width: '75%',
+  height: '50%',
+  background: 'green',
+  transform: 'translateZ(0)'
+}
+const stylesRelative = {
+  position: 'relative',
+  width: '75%',
+  height: '50%',
+  background: 'blue'
+}
+render((
+  <div style={stylesBox}>
+    <div style={stylesRelative}>
+      <AppContainer errorReporter={Redbox}><App /></AppContainer>
+    </div>
+  </div>
+), root)
+
+if (module.hot) {
+  module.hot.accept('./components/App', () => {
+    const NextApp = require('./components/App').default
+    render(
+      <AppContainer errorReporter={Redbox}>
+        <NextApp />
+      </AppContainer>,
+      root
+    )
+  })
+}

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "react-native"
   ],
   "devDependencies": {
+    "react": "^15.0.0",
     "babel-cli": "^6.9.0",
     "babel-core": "^6.9.0",
     "babel-loader": "^6.2.4",

--- a/package.json
+++ b/package.json
@@ -34,20 +34,20 @@
     "react-native"
   ],
   "devDependencies": {
-    "babel-cli": "^6.3.17",
-    "babel-core": "^6.3.21",
-    "babel-loader": "^6.0.0",
+    "babel-cli": "^6.9.0",
+    "babel-core": "^6.9.0",
+    "babel-loader": "^6.2.4",
     "babel-plugin-rewire": "^1.0.0-rc-3",
     "babel-preset-es2015": "^6.3.3",
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-0": "^6.3.13",
     "react-addons-test-utils": "^15.0.0",
-    "rimraf": "^2.3.4",
+    "rimraf": "^2.5.2",
     "semantic-release": "^4.0.0",
-    "standard": "^7.1.0",
+    "standard": "^7.1.1",
     "tap-spec": "^4.0.2",
-    "tape": "^4.0.1",
-    "webpack": "^1.9.6"
+    "tape": "^4.5.1",
+    "webpack": "^1.13.1"
   },
   "peerDependencies": {
     "react": "^15.0.0"

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   },
   "dependencies": {
     "error-stack-parser": "^1.3.6",
-    "object-assign": "^4.0.1"
+    "object-assign": "^4.0.1",
+    "react-dom": "^15.1.0"
   }
 }

--- a/src/index-no-portal.js
+++ b/src/index-no-portal.js
@@ -1,0 +1,77 @@
+import React, {Component, PropTypes} from 'react'
+import style from './style.js'
+import ErrorStackParser from 'error-stack-parser'
+import assign from 'object-assign'
+import {isFilenameAbsolute, makeUrl, makeLinkText} from './lib'
+
+export default class RedBox extends Component {
+  static propTypes = {
+    error: PropTypes.instanceOf(Error).isRequired,
+    filename: PropTypes.string,
+    editorScheme: PropTypes.string,
+    useLines: PropTypes.bool,
+    useColumns: PropTypes.bool,
+    style: PropTypes.object,
+  }
+  static displayName = 'RedBox'
+  static defaultProps = {
+    useLines: true,
+    useColumns: true
+  }
+  renderFrames (frames) {
+    const {filename, editorScheme, useLines, useColumns} = this.props
+    const {frame, file, linkToFile} = assign({}, style, this.props.style)
+    return frames.map((f, index) => {
+      let text
+      let url
+
+      if (index === 0 && filename && !isFilenameAbsolute(f.fileName)) {
+        url = makeUrl(filename, editorScheme)
+        text = makeLinkText(filename)
+      } else {
+        let lines = useLines ? f.lineNumber : null
+        let columns = useColumns ? f.columnNumber : null
+        url = makeUrl(f.fileName, editorScheme, lines, columns)
+        text = makeLinkText(f.fileName, lines, columns)
+      }
+
+      return (
+        <div style={frame} key={index}>
+          <div>{f.functionName}</div>
+          <div style={file}>
+            <a href={url} style={linkToFile}>{text}</a>
+          </div>
+        </div>
+      )
+    })
+  }
+  render () {
+    const {error} = this.props
+    const {redbox, message, stack, frame} = assign({}, style, this.props.style)
+
+    let frames
+    let parseError
+    try {
+      frames = ErrorStackParser.parse(error)
+    } catch (e) {
+      parseError = new Error('Failed to parse stack trace. Stack trace information unavailable.')
+    }
+
+    if (parseError) {
+      frames = (
+        <div style={frame} key={0}>
+          <div>{parseError.message}</div>
+        </div>
+      )
+    } else {
+      frames = this.renderFrames(frames)
+    }
+
+    return (
+      <div style={redbox}>
+        <div style={message}>{error.name}: {error.message}</div>
+        <div style={stack}>{frames}</div>
+      </div>
+    )
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,11 @@
 import React, {Component, PropTypes} from 'react'
+import ReactDOM from 'react-dom'
 import style from './style.js'
 import ErrorStackParser from 'error-stack-parser'
 import assign from 'object-assign'
 import {isFilenameAbsolute, makeUrl, makeLinkText} from './lib'
 
-export default class RedBox extends Component {
+export class RedBoxError extends Component {
   static propTypes = {
     error: PropTypes.instanceOf(Error).isRequired,
     filename: PropTypes.string,
@@ -13,7 +14,7 @@ export default class RedBox extends Component {
     useColumns: PropTypes.bool,
     style: PropTypes.object,
   }
-  static displayName = 'RedBox'
+  static displayName = 'RedBoxError'
   static defaultProps = {
     useLines: true,
     useColumns: true
@@ -73,5 +74,33 @@ export default class RedBox extends Component {
         <div style={stack}>{frames}</div>
       </div>
     )
+  }
+}
+
+// "Portal" component for actual RedBoxError component to
+// render to (directly under body). Prevents bugs as in #27.
+export default class RedBox extends Component {
+  static propTypes = {
+    error: PropTypes.instanceOf(Error).isRequired
+  }
+  static displayName = 'RedBox'
+  componentDidMount () {
+    this.el = document.createElement('div')
+    document.body.appendChild(this.el)
+    this.renderRedBoxError()
+  }
+  componentDidUpdate () {
+    this.renderRedBoxError()
+  }
+  componentWillUnmount () {
+    React.unmountComponentAtNode(this.el)
+    document.body.removeChild(this.el)
+    this.el = null
+  }
+  renderRedBoxError () {
+    ReactDOM.render(<RedBoxError {...this.props}/>, this.el)
+  }
+  render () {
+    return null
   }
 }

--- a/tests/index.js
+++ b/tests/index.js
@@ -5,36 +5,47 @@ import errorStackParserMock from './errorStackParserMock'
 import framesStub from './framesStub.json'
 import framesStubAbsoluteFilenames from './framesStubAbsoluteFilenames.json'
 import framesStubMissingFilename from './framesStubMissingFilename.json'
-import RedBox from '../src'
+import RedBox, {RedBoxError, __RewireAPI__} from '../src'
 import style from '../src/style'
 import './lib';
 
 
 const beforeEach = (framesStub) => {
-  RedBox.__Rewire__('ErrorStackParser', errorStackParserMock(framesStub))
+  __RewireAPI__.__Rewire__('ErrorStackParser', errorStackParserMock(framesStub))
 }
 
 const afterEach = () => {
-  RedBox.__ResetDependency__('ErrorStackParser')
+  __RewireAPI__.__ResetDependency__('ErrorStackParser')
 }
 
+// RedBox tests
 test('RedBox static displayName', t => {
   t.plan(1)
-  beforeEach(framesStub)
   t.equal(
     RedBox.displayName,
     'RedBox',
-    'correct static displayName property on class'
+    'correct static displayName property on class RedBox'
   )
-  afterEach()
 })
 
-test('RedBox error message', t => {
+// TODO: add missing new tests for RedBox "portal" component
+
+// RedBoxError tests
+test('RedBoxError static displayName', t => {
+  t.plan(1)
+  t.equal(
+    RedBoxError.displayName,
+    'RedBoxError',
+    'correct static displayName property on class RedBoxError'
+  )
+})
+
+test('RedBoxError error message', t => {
   t.plan(3)
   beforeEach(framesStub)
   const ERR_MESSAGE = 'funny error name'
   const error = new Error(ERR_MESSAGE)
-  const component = createComponent(RedBox, {error})
+  const component = createComponent(RedBoxError, {error})
   // renderedError = div.redbox > div.message > *
   const renderedError = component
     .props.children[0]
@@ -57,11 +68,11 @@ test('RedBox error message', t => {
   afterEach()
 })
 
-test('RedBox stack trace', t => {
+test('RedBoxError stack trace', t => {
   t.plan(1)
   beforeEach(framesStub)
   const error = new Error()
-  const component = createComponent(RedBox, {error})
+  const component = createComponent(RedBoxError, {error})
 
   const renderedStack = component
     .props.children[1]
@@ -87,12 +98,12 @@ test('RedBox stack trace', t => {
   afterEach()
 })
 
-test('RedBox with filename from react-transform-catch-errors', t => {
+test('RedBoxError with filename from react-transform-catch-errors', t => {
   t.plan(1)
   beforeEach(framesStub)
   const error = new Error()
   const filename = 'some-optional-webpack-loader!/filename'
-  const component = createComponent(RedBox, {error, filename})
+  const component = createComponent(RedBoxError, {error, filename})
 
   const renderedStack = component
     .props.children[1]
@@ -117,13 +128,13 @@ test('RedBox with filename from react-transform-catch-errors', t => {
   afterEach()
 })
 
-test('RedBox with filename and editorScheme', t => {
+test('RedBoxError with filename and editorScheme', t => {
   t.plan(1)
   beforeEach(framesStub)
   const error = new Error()
   const filename = 'some-optional-webpack-loader!/filename'
   const editorScheme = 'subl'
-  const component = createComponent(RedBox, {error, filename, editorScheme})
+  const component = createComponent(RedBoxError, {error, filename, editorScheme})
 
   const renderedStack = component
     .props.children[1]
@@ -148,13 +159,13 @@ test('RedBox with filename and editorScheme', t => {
   afterEach()
 })
 
-test('RedBox with absolute filenames', t => {
+test('RedBoxError with absolute filenames', t => {
   t.plan(1)
   beforeEach(framesStubAbsoluteFilenames)
   const error = new Error()
   const filename = 'some-optional-webpack-loader!/filename'
   const editorScheme = 'subl'
-  const component = createComponent(RedBox, {error, filename, editorScheme})
+  const component = createComponent(RedBoxError, {error, filename, editorScheme})
 
   const renderedStack = component
     .props.children[1]
@@ -179,14 +190,14 @@ test('RedBox with absolute filenames', t => {
   afterEach()
 })
 
-test('RedBox with absolute filenames but unreliable line numbers', t => {
+test('RedBoxError with absolute filenames but unreliable line numbers', t => {
   t.plan(1)
   beforeEach(framesStubAbsoluteFilenames)
   const error = new Error()
   const filename = 'some-optional-webpack-loader!/filename'
   const editorScheme = 'subl'
   const useLines = false
-  const component = createComponent(RedBox, {error, filename, editorScheme, useLines})
+  const component = createComponent(RedBoxError, {error, filename, editorScheme, useLines})
 
   const renderedStack = component
     .props.children[1]
@@ -211,14 +222,14 @@ test('RedBox with absolute filenames but unreliable line numbers', t => {
   afterEach()
 })
 
-test('RedBox with absolute filenames but unreliable column numbers', t => {
+test('RedBoxError with absolute filenames but unreliable column numbers', t => {
   t.plan(1)
   beforeEach(framesStubAbsoluteFilenames)
   const error = new Error()
   const filename = 'some-optional-webpack-loader!/filename'
   const editorScheme = 'subl'
   const useColumns = false
-  const component = createComponent(RedBox, {error, filename, editorScheme, useColumns})
+  const component = createComponent(RedBoxError, {error, filename, editorScheme, useColumns})
 
   const renderedStack = component
     .props.children[1]
@@ -243,11 +254,11 @@ test('RedBox with absolute filenames but unreliable column numbers', t => {
   afterEach()
 })
 
-test('RedBox stack trace with missing filename', t => {
+test('RedBoxError stack trace with missing filename', t => {
   t.plan(1)
   beforeEach(framesStubMissingFilename)
   const error = new Error()
-  const component = createComponent(RedBox, {error})
+  const component = createComponent(RedBoxError, {error})
 
   const renderedStack = component
     .props.children[1]
@@ -273,9 +284,9 @@ test('RedBox stack trace with missing filename', t => {
   afterEach()
 })
 
-test('RedBox with throwing stack trace parser', t => {
+test('RedBoxError with throwing stack trace parser', t => {
   t.plan(3)
-  RedBox.__Rewire__('ErrorStackParser', {
+  __RewireAPI__.__Rewire__('ErrorStackParser', {
     parse: function () {
       // This mimicks the former behavior of stacktracejs,
       // see https://github.com/stacktracejs/stackframe/issues/11.
@@ -284,7 +295,7 @@ test('RedBox with throwing stack trace parser', t => {
   })
   const ERR_MESSAGE = "original error message"
   const error = new TypeError(ERR_MESSAGE)
-  const component = createComponent(RedBox, {error})
+  const component = createComponent(RedBoxError, {error})
 
   const renderedError = component
     .props.children[0]


### PR DESCRIPTION
This is based on @cpsubrian 's work (#28). I had to do this from scratch because it was easier than migrating from the out of date PR. 

This still needs tests for the new code, i.e. the portal.