### PR TITLE
fix(package): Loosen react-dom dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
   "dependencies": {
     "error-stack-parser": "^1.3.6",
     "object-assign": "^4.0.1",
-    "react-dom": "^15.1.0"
+    "react-dom": "^0.14.0 || ^15.0.0"
   }
 }


### PR DESCRIPTION
This commit resolves #61 by allowing the project to depend on `react-dom` 0.14.x or 15.x.x.

See similar changes in 8930b195a014f99432c3dddd5a6f1a2c818f34a0.