### PR TITLE
Fix misleading code in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ import App from './components/App'
 const root = document.getElementById('root')
 
 if (__DEV__) {
-  const RedBox = require('redbox-react')
+  const RedBox = require('redbox-react').RedBoxError
   try {
     render(<App />, root)
   } catch (e) {


### PR DESCRIPTION
Since there are ES6 modules, there is nothing useful by just requiring module. Needs to be either `default` or `RedBoxError` which is more useful in this case.